### PR TITLE
Add JSONP Helper for Meetup-API

### DIFF
--- a/_chapters/berlin.md
+++ b/_chapters/berlin.md
@@ -6,6 +6,7 @@ tagline: "Where everything started... and you can take a ride in a rotating TV t
 twitter: OTS_BLN
 widget_id: 276335676528672768
 discourse_group: TeamBerlin
+meetup_group: "opentechschool-berlin"
 background: berlin.jpg
 does:
   hackership

--- a/_includes/components/member_count_example.html
+++ b/_includes/components/member_count_example.html
@@ -1,0 +1,14 @@
+<div id="js-membercount">
+</div>
+
+<script id="tmpl-membercount" type="text/template">
+  ${data.members} Learners
+</script>
+
+
+<script type="text/javascript">
+onStartUp(function() { fetchJSONPAndRender(
+  'https://api.meetup.com/{{page.meetup_group}}?key=' + MEETUPCOM_KEY,
+  'js-membercount',
+  ['tmpl-membercount'])});
+</script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -131,3 +131,4 @@
 <!-- our external javascript scripts -->
 <script type="text/javascript" src="/assets/statics/polyfills/fetch.js"></script>
 <script type="text/javascript" src="/assets/statics/polyfills/template.js"></script>
+<script type="text/javascript" src="/assets/statics/polyfills/jsonp.js"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,6 +11,7 @@
     <script type="text/javascript">
     (function(){
     	var _queue = [];
+    	window.MEETUPCOM_KEY = '38406b383fa43605b6b234269316';
     	window.onStartUp = function(fn){
     		if (document.readyState === "loading") {
     			_queue.push(fn);
@@ -27,18 +28,13 @@
 		        });
 		    }
 		}
-		window.fetchAndRender = function(
-			sourceUrl,   // link to a json URL we will fetch
-			targetId,  // the target this should be rendered into
-			templates,   // any templateIDs it'd like us to fetch for them
-			fn           // the function to call
-			) {
-			var target = document.getElementById(targetId);
-			return fetch(sourceUrl)
-				.then(function(resp) { return resp.json() })
-				.then(function(data) {
+		function _thenRender(target, templates, fn) {
+			return (function(prms) {
+				return prms.then(function(data) {
 					var args = (templates || []).map(
 						function (tmpl) { return document.getElementById(tmpl).innerHTML});
+					// no function provided? directly render by passing data to first template
+					if (!fn) return args[0].template(data);
 					args.unshift(data);
 					return fn.apply(fn, args);
 				})
@@ -48,6 +44,32 @@
 				.catch(function(error){
 					target.innerHTML = error
 				});
+
+			})
+		}
+		window.fetchAndRender = function(
+			sourceUrl,   // link to a json URL we will fetch
+			targetId,    // the target this should be rendered into
+			templates,   // any templateIDs it'd like us to fetch for them
+			fn           // the function to call
+			) {
+			var target = document.getElementById(targetId);
+			return _thenRender(target, templates, fn)(fetch(sourceUrl)
+				.then(function(resp) { return resp.json() }));
+		}
+		window.fetchJSONPAndRender = function(
+			sourceUrl,   // link to a json URL we will fetch
+			targetId,    // the target this should be rendered into
+			templates,   // any templateIDs it'd like us to fetch for them
+			fn           // the function to call
+			) {
+			var target = document.getElementById(targetId);
+			var prms = new Promise(function (resolve, reject){
+				JSONP(sourceUrl, resolve);
+			});
+			console.log(prms);
+			_thenRender(target, templates, fn)(prms);
+			return prms;
 		}
 	})()
     </script>

--- a/_layouts/chapter.html
+++ b/_layouts/chapter.html
@@ -17,6 +17,10 @@ layout: default
         {{page.tagline}}
       </h2>
     {% endif %}
+
+      {% if page.meetup_group %}
+        {% include components/member_count_example.html %}
+      {% endif %}
   </div>
   </header>
 

--- a/assets/statics/polyfills/jsonp.js
+++ b/assets/statics/polyfills/jsonp.js
@@ -1,0 +1,109 @@
+/**
+ * JSONP sets up and allows you to execute a JSONP request
+ * @param {String} url  The URL you are requesting with the JSON data
+ * @param {Object} data The Data object you want to generate the URL params from
+ * @param {String} method  The method name for the callback function. Defaults to callback (for example, flickr's is "jsoncallback")
+ * @param {Function} callback  The callback you want to execute as an anonymous function. The first parameter of the anonymous callback function is the JSON
+ *
+ * @example
+ * JSONP('http://twitter.com/users/oscargodson.json',function(json){
+ *  document.getElementById('avatar').innerHTML = '<p>Twitter Pic:</p><img src="'+json.profile_image_url+'">';
+ * });
+ *
+ * @example
+ * JSONP('http://api.flickr.com/services/feeds/photos_public.gne',{'id':'12389944@N03','format':'json'},'jsoncallback',function(json){
+ *  document.getElementById('flickrPic').innerHTML = '<p>Flickr Pic:</p><img src="'+json.items[0].media.m+'">';
+ * });
+ *
+ * @example
+ * JSONP('http://graph.facebook.com/FacebookDevelopers', 'callback', function(json){
+ *  document.getElementById('facebook').innerHTML = json.about;
+ * });
+ */
+(function( window, undefined) {
+  var JSONP = function(url,data,method,callback){
+    //Set the defaults
+    url = url || '';
+    data = data || {};
+    method = method || '';
+    callback = callback || function(){};
+    
+    //Gets all the keys that belong
+    //to an object
+    var getKeys = function(obj){
+      var keys = [];
+      for(var key in obj){
+        if (obj.hasOwnProperty(key)) {
+          keys.push(key);
+        }
+        
+      }
+      return keys;
+    }
+
+    //Turn the data object into a query string.
+    //Add check to see if the second parameter is indeed
+    //a data object. If not, keep the default behaviour
+    if(typeof data == 'object'){
+      var queryString = '';
+      var keys = getKeys(data);
+      for(var i = 0; i < keys.length; i++){
+        queryString += encodeURIComponent(keys[i]) + '=' + encodeURIComponent(data[keys[i]])
+        if(i != keys.length - 1){ 
+          queryString += '&';
+        }
+      }
+      url += '?' + queryString;
+    } else if(typeof data == 'function'){
+      method = data;
+      callback = method;
+    }
+
+    //If no method was set and they used the callback param in place of
+    //the method param instead, we say method is callback and set a
+    //default method of "callback"
+    if(typeof method == 'function'){
+      callback = method;
+      method = 'callback';
+    }
+  
+    //Check to see if we have Date.now available, if not shim it for older browsers
+    if(!Date.now){
+      Date.now = function() { return new Date().getTime(); };
+    }
+
+    //Use timestamp + a random factor to account for a lot of requests in a short time
+    //e.g. jsonp1394571775161 
+    var timestamp = Date.now();
+    var generatedFunction = 'jsonp'+Math.round(timestamp+Math.random()*1000001)
+
+    //Generate the temp JSONP function using the name above
+    //First, call the function the user defined in the callback param [callback(json)]
+    //Then delete the generated function from the window [delete window[generatedFunction]]
+    window[generatedFunction] = function(json){
+      callback(json);
+
+      // IE8 throws an exception when you try to delete a property on window
+      // http://stackoverflow.com/a/1824228/751089
+      try {
+        delete window[generatedFunction];
+      } catch(e) {
+        window[generatedFunction] = undefined;
+      }
+
+    };
+
+    //Check if the user set their own params, and if not add a ? to start a list of params
+    //If in fact they did we add a & to add onto the params
+    //example1: url = http://url.com THEN http://url.com?callback=X
+    //example2: url = http://url.com?example=param THEN http://url.com?example=param&callback=X
+    if(url.indexOf('?') === -1){ url = url+'?'; }
+    else{ url = url+'&'; }
+  
+    //This generates the <script> tag
+    var jsonpScript = document.createElement('script');
+    jsonpScript.setAttribute("src", url+method+'='+generatedFunction);
+    document.getElementsByTagName("head")[0].appendChild(jsonpScript)
+  }
+  window.JSONP = JSONP;
+})(window);


### PR DESCRIPTION
The meetup API still doesn't allow us to make proper CORS requests so 
this PR adds a JSONP library and an additional fetchJSONPAndRender 
function.

It furthermore simplifies the usage pattern of both `fetch*AndRender` 
functions: if you don't supply a render function yourself it will 
directly pass the data into the first template passed in.

Last but not least, it features an example of this new feature with the 
meetup API on the chapter pages. Check it out at `/berlin`.


OpenTechSchool:meetup-cors